### PR TITLE
Add BulkLoadedPrograms and BulkMillNCVariables, fix JSON size bug

### DIFF
--- a/RESTclientExample/Bulk.cs
+++ b/RESTclientExample/Bulk.cs
@@ -94,6 +94,27 @@ namespace WcfDataService
       [DataMember]
       public WcfDataServices.UnmanagedDataTypes.BulkCurrentPartSetupType BulkStruct;
     }
+	
+    /// <summary>
+    /// wrapper for BulkMillNCVariable
+    /// </summary>
+    [DataContract(Namespace = "WcfDataServices")]
+    public class BulkMillNCVariableBox : Bulk
+    {
+        [DataMember]
+        public WcfDataServices.UnmanagedDataTypes.BulkMillNCVariable BulkStruct;
+    }
+
+    /// <summary>
+    /// wrapper for BulkLoadedPrograms
+    /// </summary>
+    [DataContract(Namespace = "WcfDataServices")]
+    public class BulkLoadedProgramsBox : Bulk
+    {
+        [DataMember]
+        public WcfDataServices.UnmanagedDataTypes.BulkLoadedPrograms BulkStruct;
+    }
+	
     /// <summary>
     /// base transer class.
     /// </summary>

--- a/RESTclientExample/RestClient.cs
+++ b/RESTclientExample/RestClient.cs
@@ -92,14 +92,14 @@ namespace RESTclient
         public String Token { get { return token; } }
 
 
-        private void ReadResponse(Stream source, byte[] buffer, int content_length)
+        private void ReadResponse(Stream source, byte[] buffer, int content_length, int already_done = 0)
         {
-            int read_so_far = 0;
+            int read_so_far = already_done;
             try
             {
                 while (read_so_far < content_length - 1)
                 {
-                    read_so_far += source.Read(buffer, read_so_far, content_length);
+                    read_so_far += source.Read(buffer, read_so_far, content_length - read_so_far);
                 }
             }
             catch (IOException err)
@@ -735,7 +735,7 @@ namespace RESTclient
                                     int bytes = s.EndRead(async);
                                     if (bytes < R.ContentLength)
                                     {
-                                        ReadResponse(s, buffer, (int)R.ContentLength);
+                                        ReadResponse(s, buffer, (int)R.ContentLength, bytes);
                                     }
                                     
                                     Response = Encoding.UTF8.GetString(buffer);
@@ -746,9 +746,9 @@ namespace RESTclient
                                     R.Close();
                                     waithandle.Set();
                                 }
-                                catch
+                                catch(Exception e)
                                 {
-                                    System.Diagnostics.Debug.WriteLine("failed to read bytes");
+                                    System.Diagnostics.Debug.WriteLine("Failed to read bytes:" + e);
                                     s.Close();
                                     R.Close();
                                     failhandle.Set();

--- a/RESTclientExample/UnmanagedDataTypes.cs
+++ b/RESTclientExample/UnmanagedDataTypes.cs
@@ -304,6 +304,78 @@ namespace WcfDataServices
             [DataMember]
             double XYSkewAngle;
         }
-    }
+		
+        private const int MAX_MILL_VAR_ARRAY_LENGTH = 500;
+        public enum operand_type_enum: int
+        {
+            DATA_OPERAND_TYPE,
+            INVALID_OPERAND,
+            VACANT_OPERAND,
+            NULL_OPERAND
+        }
+        [DataContract]
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct BulkMillNCVariable
+        {
+            [DataMember]
+            public int arrayLength;
+            [DataMember]
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_MILL_VAR_ARRAY_LENGTH)]
+            public double[] operandData;
+            [DataMember]
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_MILL_VAR_ARRAY_LENGTH)]
+            public operand_type_enum[] operandType;
+            [DataMember]
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_MILL_VAR_ARRAY_LENGTH)]
+            public int[] CopyVariables;
+        }
 
+        private const int MAX_NUM_RETURNED_FILES = 16;
+        [DataContract]
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct BulkLoadedPrograms
+        {
+            public void Init()
+            {
+                this.numLoadedFiles = 0;
+                this.fileNames = new byte[MAX_NUM_RETURNED_FILES * COMM_STRING_MAX_SIZE];
+                for (int i = 0; i < MAX_NUM_RETURNED_FILES * COMM_STRING_MAX_SIZE; i++)
+                {
+                    fileNames[i] = 0;
+                }
+            }
+            public List<string> GetLoadedPrograms()
+            {
+                List<string> names = new List<string>();
+                for (int i = 0; i < numLoadedFiles; i++)
+                {
+                    string file = "";
+                    byte[] bytes = new byte[COMM_STRING_MAX_SIZE];
+                    //Length of non-zero array
+                    int arrLength = 0;
+                    for (int j = 0; j < COMM_STRING_MAX_SIZE; j++, arrLength++)
+                    {
+                        byte ch = fileNames[j + i * COMM_STRING_MAX_SIZE];
+                        if (ch == 0)
+                            break;
+                        bytes[j] = ch;
+                    }
+                    byte[] temp = new byte[arrLength];
+                    Array.Copy(bytes, temp, arrLength);
+                    file = Encoding.ASCII.GetString(temp);
+                    names.Add(file);
+                }
+                return names;
+            }
+            [DataMember]
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_NUM_RETURNED_FILES * COMM_STRING_MAX_SIZE)]
+            public byte[] fileNames;
+            [DataMember]
+            public int numLoadedFiles;
+            [DataMember]
+            public const int maxFiles = MAX_NUM_RETURNED_FILES;
+            [DataMember]
+            public const int strMaxSize = COMM_STRING_MAX_SIZE;
+        }
+    }
 }


### PR DESCRIPTION
Adds the BulkStructs needed to get paths of all programs loaded in the program manager (BulkLoadePrograms) and to get/set some mill NC variables (BulkMillNCVariables).

Also fixes a bug that causes RESTful client to fail if the JSON size is too large for a single packet read.